### PR TITLE
Update seff-array.py

### DIFF
--- a/seff-array.py
+++ b/seff-array.py
@@ -540,7 +540,7 @@ def main(arrayID, m, t, c, v):
         cpuTime = line[8]
         state = line[7]
 
-        if maxRSS == "" or maxRSS == "" or cpuTime == "":
+        if maxRSS == "" or maxRSS == "0" or cpuTime == "":
             continue
 
         maxRSS = str_to_mb(maxRSS + "B")

--- a/seff-array.py
+++ b/seff-array.py
@@ -540,7 +540,7 @@ def main(arrayID, m, t, c, v):
         cpuTime = line[8]
         state = line[7]
 
-        if maxRSS == "" or cpuTime == "":
+        if maxRSS == "" or maxRSS == "" or cpuTime == "":
             continue
 
         maxRSS = str_to_mb(maxRSS + "B")


### PR DESCRIPTION
Our sacct seems always to show zero (the digit zero) for maxRSS of the extern job step, which causes a value error in str_to_mb().  This fix allows a character zero as well as a null value for maxRSS to be ignored.